### PR TITLE
getChildCount()가 0인 경우 함수를 종료하게 함

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.1.3-AZAR
-VERSION_CODE=2
+VERSION_NAME=0.1.3-AZAR-1
+VERSION_CODE=3
 GROUP=org.lucasr.twowayview
 
 POM_DESCRIPTION=An AdapterView with support for vertical and horizontal scrolling.

--- a/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
+++ b/library/src/main/java/org/lucasr/twowayview/TwoWayView.java
@@ -4956,6 +4956,9 @@ public class TwoWayView extends AdapterView<ListAdapter> implements
 
     void fillGap(boolean down) {
         final int childCount = getChildCount();
+        if (childCount == 0) {
+            return;
+        }
 
         if (down) {
             final int start = getStartEdge();


### PR DESCRIPTION
계속해서 생기는 [TwoWayView 크래시](https://azarlive.com:8443/admin/azarapp/crashreport/201510050db0b446995743a3a1934edd982e5d1a/?_changelist_filters=q%3DTwoWayView%26p%3D0%26version%3D184)에 대해서, ChildView가 null이 되어서 앱이 죽지 않도록 처리했습니다.
